### PR TITLE
fix: refresh session/displays on interval

### DIFF
--- a/cmd/set/set.go
+++ b/cmd/set/set.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/charmbracelet/log"
 	"github.com/joshbeard/walsh/internal/cli"
-	"github.com/joshbeard/walsh/internal/session"
 	"github.com/spf13/cobra"
 )
 
@@ -33,14 +32,7 @@ func Command() *cobra.Command {
 			"  walsh s 1 path/to/images\n" +
 			"  walsh set --interval 60 -d 0",
 		Run: func(cmd *cobra.Command, args []string) {
-			display, sess, err := cli.Setup(cmd, args)
-			if err != nil {
-				log.Fatal(err)
-			}
-			opts.display = display
-
-			err = setWallpaper(sess, opts)
-			if err != nil {
+			if err := setWallpaper(cmd, args, opts); err != nil {
 				log.Fatalf("Error: %v", err)
 			}
 		},
@@ -58,8 +50,14 @@ func Command() *cobra.Command {
 	return cmd
 }
 
-func setWallpaper(sess *session.Session, opts setOptions) error {
-	err := sess.SetWallpaper(opts.srcs, opts.display)
+func setWallpaper(cmd *cobra.Command, args []string, opts setOptions) error {
+	display, sess, err := cli.Setup(cmd, args)
+	if err != nil {
+		log.Fatal(err)
+	}
+	opts.display = display
+
+	err = sess.SetWallpaper(opts.srcs, opts.display)
 	if err != nil {
 		log.Errorf("Error setting wallpaper: %s", err)
 		return err
@@ -73,6 +71,12 @@ func setWallpaper(sess *session.Session, opts setOptions) error {
 	defer ticker.Stop()
 
 	for range ticker.C {
+		display, sess, err := cli.Setup(cmd, args)
+		if err != nil {
+			log.Fatal(err)
+		}
+		opts.display = display
+
 		if err := sess.SetWallpaper(opts.srcs, opts.display); err != nil {
 			log.Errorf("Error setting wallpaper: %s", err)
 			return err

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -177,14 +177,6 @@ func (s *Session) SetWallpaper(sources []string, displayStr string) error {
 	errChan := make(chan error, len(displays))
 	defer close(errChan)
 
-	concurrent := true
-	// Workaround for setting wallpapers on X11 sessions. Setting wallpapers
-	// on all displays concurrently often only sets it on one and leaves the
-	// others black. This is a workaround to set wallpapers sequentially.
-	if s.sessType == SessionTypeX11Unknown {
-		concurrent = false
-	}
-
 	// Function to process each display
 	processDisplay := func(d Display) {
 		defer wg.Done()
@@ -225,13 +217,8 @@ func (s *Session) SetWallpaper(sources []string, displayStr string) error {
 	}
 
 	for _, d := range displays {
-		if concurrent {
-			wg.Add(1)
-			go processDisplay(d)
-		} else {
-			wg.Add(1)
-			processDisplay(d)
-		}
+		wg.Add(1)
+		go processDisplay(d)
 	}
 
 	wg.Wait()

--- a/internal/source/source.go
+++ b/internal/source/source.go
@@ -302,9 +302,9 @@ func downloadSSHImage(src Image, dest string) (Image, error) {
 	sshCmd := fmt.Sprintf("scp %s:\"%s\" \"%s\"", addr, path, dest)
 
 	// Run the SSH command.
-	_, err := util.RunCmd(sshCmd)
+	result, err := util.RunCmd(sshCmd)
 	if err != nil {
-		return Image{}, fmt.Errorf("failed to run SSH command: %w", err)
+		return Image{}, fmt.Errorf("failed to run SSH command: %w output: %s", err, result)
 	}
 
 	checksum, err := util.Sha256(dest)


### PR DESCRIPTION
When running `set` with `--interval`, the session should refresh with each run to deal with changes in monitor configuration.