### PR TITLE
fix: download dir; lock files

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ The default configuration is as follows:
 
 ```yaml
 # A list of directories or URIs to source images from.
-sources: []
+sources:
+  - ${XDG_HOME}/Pictures/Wallpapers
 
 # The file to track the currently set wallpaper.
 current: ${XDG_DATA_HOME}/walsh/current.json
@@ -281,9 +282,9 @@ cache_size: 50
 # The interval in seconds to set a new wallpaper. Set to 0 to disable.
 interval: 0
 
-# A destination URI to download images to. This is used by the 'download'
-# command. Uses the same syntax as the 'sources' list.
-download_dest: ""
+# A destination path to download images to. This is used by the 'download'
+# command.
+download_dest: ${XDG_HOME}/Pictures/Wallpapers
 ```
 
 * On Linux and BSD, `${XDG_CONFIG_HOME}` defaults to `~/.config`,

--- a/cmd/download/download.go
+++ b/cmd/download/download.go
@@ -114,7 +114,10 @@ func commonSetup(cmd *cobra.Command, args []string, opts dlOptions) (*session.Se
 }
 
 func processDownloads(sess *session.Session, dest string) {
-	srcs := []string{"dir:///home/josh/Pictures/GoSiMac"}
+	homeDir := os.Getenv("HOME")
+	gosimacDir := filepath.Join(homeDir, "Pictures", "GoSiMac")
+
+	srcs := []string{"dir://" + gosimacDir}
 	images, err := source.GetImages(srcs)
 	if err != nil {
 		log.Fatal(err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,6 +132,13 @@ func (c Config) createDirs() error {
 		}
 	}
 
+	if !util.FileExists(c.DownloadDest) {
+		err := util.MkDir(c.DownloadDest)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -142,9 +149,13 @@ func defaultConfig() *Config {
 		HistoryFile:   xdg.DataHome + "/walsh/history.json",
 		ListsDir:      xdg.DataHome + "/walsh/lists",
 		CacheDir:      xdg.CacheHome + "/walsh/cache",
+		DownloadDest:  xdg.Home + "/Pictures/Wallpapers",
 		HistorySize:   50,
 		CacheSize:     50,
 		Interval:      0,
+		Sources: []string{
+			"dir://" + xdg.Home + "/Pictures/Wallpapers",
+		},
 	}
 }
 
@@ -159,5 +170,29 @@ func applyDefaults(cfg *Config, defaults *Config) {
 
 	if cfg.CacheSize == 0 {
 		cfg.CacheSize = defaults.CacheSize
+	}
+
+	if cfg.DownloadDest == "" {
+		cfg.DownloadDest = defaults.DownloadDest
+	}
+
+	if cfg.BlacklistFile == "" {
+		cfg.BlacklistFile = defaults.BlacklistFile
+	}
+
+	if cfg.CurrentFile == "" {
+		cfg.CurrentFile = defaults.CurrentFile
+	}
+
+	if cfg.HistoryFile == "" {
+		cfg.HistoryFile = defaults.HistoryFile
+	}
+
+	if cfg.ListsDir == "" {
+		cfg.ListsDir = defaults.ListsDir
+	}
+
+	if cfg.Sources == nil {
+		cfg.Sources = defaults.Sources
 	}
 }

--- a/internal/session/mac.go
+++ b/internal/session/mac.go
@@ -5,10 +5,10 @@ package session
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
+	"github.com/charmbracelet/log"
 	"github.com/joshbeard/walsh/internal/util"
 )
 
@@ -56,7 +56,7 @@ func (m macos) GetDisplays() ([]Display, error) {
 	}
 
 	var displays []Display
-	for i, display := range spDisplays {
+	for _, display := range spDisplays {
 		displayMap, ok := display.(map[string]interface{})
 		if !ok {
 			log.Fatalf("Error asserting display as map")
@@ -65,11 +65,12 @@ func (m macos) GetDisplays() ([]Display, error) {
 		if !ok {
 			log.Fatalf("Error asserting spdisplays_ndrvs as array")
 		}
-		fmt.Printf("Display %d has %d items in 'spdisplays_ndrvs'\n", i+1, len(ndrvs))
 
 		for ii := range ndrvs {
-			displays = append(displays, Display{Name: fmt.Sprintf("%d", ii+1)})
+			displays = append(displays, Display{Index: ii + 1, Name: fmt.Sprintf("%d", ii+1)})
 		}
+
+		log.Debugf("Found %d displays", len(ndrvs))
 	}
 
 	return displays, nil


### PR DESCRIPTION
* Fix the download directory to be `~/Pictures/GoSiMac` and work on different platforms.
* Set a default source and download destination to `~/Pictures/Wallpapers`
* Lock the current and history file update operations when running concurrently to avoid corruption.