### PR TITLE
Fix Hyprland display indexing

### DIFF
--- a/internal/session/hyprland.go
+++ b/internal/session/hyprland.go
@@ -79,10 +79,11 @@ func (h hyprland) parseDisplays(output string) ([]Display, error) {
 	}
 
 	displays := []Display{}
-	for _, monitor := range jsonOutput {
+	for i, monitor := range jsonOutput {
 		displays = append(displays, Display{
 			Name:  monitor["name"].(string),
-			Index: int(monitor["id"].(float64)),
+			Index: i,
+			// Index: int(monitor["id"].(float64)),
 		})
 	}
 


### PR DESCRIPTION
Use the index in which the display is returned from the `hyprctl` output for the display index, making it consistent with other session types.

This previously used Hyprland's `id` attribute. This fixes a bug with blacklisting - the display was inconsistent between discovering the display and setting a new wallpaper.